### PR TITLE
feat:Add hook to ignore timeshift-btrfs

### DIFF
--- a/biglinux-improve-compatibility/usr/share/libalpm/hooks/biglinux-osprober.hook
+++ b/biglinux-improve-compatibility/usr/share/libalpm/hooks/biglinux-osprober.hook
@@ -1,0 +1,10 @@
+[Trigger]
+Operation = Install
+Operation = Upgrade
+Type = Package
+Target = os-prober
+
+[Action]
+Description = Apply modifications to /usr/lib/os-probes/50mounted-tests
+When = PostTransaction
+Exec = /bin/sh -c "sed -i 's|subvols=\$(btrfs subvolume list \"\$tmpmnt\" \| cut -d '\'' '\'' -f 9)|subvols=\$(btrfs subvolume list \"\$tmpmnt\" \| cut -d '\'' '\'' -f 9 \| grep -v \"timeshift-btrfs\")|' /usr/lib/os-probes/50mounted-tests"


### PR DESCRIPTION
This fix's main purpose is to ignore in grub that timeshift-btrfs after restoring the system, remove the amount of entries and keep only the necessary ones for BigLinux.