### PR TITLE
refactor: improve code quality in virt-manager hook scripts

### DIFF
--- a/biglinux-improve-compatibility/usr/share/libalpm/hooks/z-biglinux-virt-manager-config-install.hook
+++ b/biglinux-improve-compatibility/usr/share/libalpm/hooks/z-biglinux-virt-manager-config-install.hook
@@ -10,3 +10,4 @@ Target = virt-manager
 Description = Configure virt-manager
 When = PostTransaction
 Exec = /usr/share/libalpm/scripts/biglinux-virt-manager-config-install
+Depends = libvirt

--- a/biglinux-improve-compatibility/usr/share/libalpm/scripts/biglinux-virt-manager-config-install
+++ b/biglinux-improve-compatibility/usr/share/libalpm/scripts/biglinux-virt-manager-config-install
@@ -20,13 +20,6 @@ if [ -n "$(ip -o -4 a | grep $libvirtNetRange)" ]; then
     sed -i "s/$libvirtNetRange/$newLibvirtNetRange/g" /etc/libvirt/qemu/networks/default.xml
 fi
 
-# firewallBackend=$(awk '/^firewall_backend/ { gsub(/"/, "", $3); print $3 }' /etc/libvirt/network.conf)
-# if [ "$firewallBackend" != "iptables" ];then
-#     sed -i '/^firewall_backend/d' /etc/libvirt/network.conf
-#     echo 'firewall_backend = "iptables"' | tee -a /etc/libvirt/network.conf > /dev/null
-#     systemctl restart libvirtd.service
-# fi
-
 # Aceita bridge em todas as redes
 if [ -e /etc/qemu/bridge.conf ] && [ -z "$(grep 'allow all' /etc/qemu/bridge.conf)" ]; then
     echo "allow all" | tee -a /etc/qemu/bridge.conf > /dev/null

--- a/biglinux-improve-compatibility/usr/share/libalpm/scripts/biglinux-virt-manager-config-install
+++ b/biglinux-improve-compatibility/usr/share/libalpm/scripts/biglinux-virt-manager-config-install
@@ -25,10 +25,6 @@ if [ -e /etc/qemu/bridge.conf ] && [ -z "$(grep 'allow all' /etc/qemu/bridge.con
     echo "allow all" | tee -a /etc/qemu/bridge.conf > /dev/null
 fi
 
-# Starta o libvirtd
-# systemctl start virtqemud.service
-systemctl start libvirtd.service
-
 # Configura, starta e coloca no autostart a rede do libvirt
 network=$(LANG=C virsh net-list | grep default)
 if [ -z "$network" ];then
@@ -43,6 +39,5 @@ if [ "$(awk '{print $3}' <<< $network)" != "yes" ];then
     virsh net-autostart default
 fi
 
-# Habilita o libvirtd para iniciar no boot
-# systemctl enable virtqemud.service
-systemctl enable libvirtd.service
+# Enable and start libvirtd
+systemctl enable --now libvirtd.service

--- a/biglinux-improve-compatibility/usr/share/libalpm/scripts/biglinux-virt-manager-config-install
+++ b/biglinux-improve-compatibility/usr/share/libalpm/scripts/biglinux-virt-manager-config-install
@@ -1,5 +1,7 @@
 #!/usr/bin/bash
 
+network_file=/etc/libvirt/qemu/networks/default.xml
+
 # Adiciona os grupos libvirt e libvirt-qemu a todos usuarios acima de 1000
 for user in $(awk -F':' '{ if ($3 >= 1000 && $1 != "nobody") print $1 }' /etc/passwd); do
     usermod -a -G libvirt $user
@@ -9,15 +11,15 @@ for user in $(awk -F':' '{ if ($3 >= 1000 && $1 != "nobody") print $1 }' /etc/pa
 done
 
 # Backup do default.xml
-if [ ! -e "/etc/libvirt/qemu/networks/default.xml.bkp" ] && [ -e "/etc/libvirt/qemu/networks/default.xml" ];then
-    cp /etc/libvirt/qemu/networks/default.xml /etc/libvirt/qemu/networks/default.xml.bkp
+if [ ! -e "${network_file}.bkp" ] && [ -e "$network_file" ];then
+    cp "$network_file" "${network_file}.bkp"
 fi
 
 # Verifica se o range de ip usado pelo libvirt não está sendo usado por outro rede
-libvirtNetRange=$(grep -oP "(?<=ip address=')[0-9]+\.[0-9]+\.[0-9]+" /etc/libvirt/qemu/networks/default.xml)
+libvirtNetRange=$(grep -oP "(?<=ip address=')[0-9]+\.[0-9]+\.[0-9]+" "$network_file")
 if [ -n "$(ip -o -4 a | grep $libvirtNetRange)" ]; then
     newLibvirtNetRange=$(awk -F. '{print $1 "." $2 "." $3+1}' <<< $libvirtNetRange)
-    sed -i "s/$libvirtNetRange/$newLibvirtNetRange/g" /etc/libvirt/qemu/networks/default.xml
+    sed -i "s/$libvirtNetRange/$newLibvirtNetRange/g" "$network_file"
 fi
 
 # Aceita bridge em todas as redes
@@ -28,7 +30,7 @@ fi
 # Configura, starta e coloca no autostart a rede do libvirt
 network=$(LANG=C virsh net-list | grep default)
 if [ -z "$network" ];then
-    virsh net-define /etc/libvirt/qemu/networks/default.xml
+    virsh net-define "$network_file"
 fi
 network=$(LANG=C virsh net-list | grep default)
 if [ "$(awk '{print $2}' <<< $network)" != "active" ];then

--- a/biglinux-improve-compatibility/usr/share/libalpm/scripts/biglinux-virt-manager-config-remove
+++ b/biglinux-improve-compatibility/usr/share/libalpm/scripts/biglinux-virt-manager-config-remove
@@ -1,5 +1,7 @@
 #!/usr/bin/bash
 
+network_file=/etc/libvirt/qemu/networks/default.xml
+
 # Adiciona os grupos libvirt e libvirt-qemu a todos usuarios acima de 1000
 for user in $(awk -F':' '{ if ($3 >= 1000 && $1 != "nobody") print $1 }' /etc/passwd); do
     gpasswd -d $user libvirt
@@ -7,11 +9,11 @@ for user in $(awk -F':' '{ if ($3 >= 1000 && $1 != "nobody") print $1 }' /etc/pa
 done
 
 # Apaga backup do default.xml
-if [ -e "/etc/libvirt/qemu/networks/default.xml" ]; then
-    rm "/etc/libvirt/qemu/networks/default.xml"
+if [ -e "$network_file" ]; then
+    rm "$network_file"
 fi
-if [ -e "/etc/libvirt/qemu/networks/default.xml.bkp" ]; then
-    rm "/etc/libvirt/qemu/networks/default.xml.bkp"
+if [ -e "${network_file}.bkp" ]; then
+    rm "{$network_file}.bkp"
 fi
 
 # Revert bridge ao original


### PR DESCRIPTION
Pequenas refatorações nos scripts para simplificar e melhorar a legibilidade, com a adição do `libvirt` como dependência na `Action` no hook, já que parte do script depende do `virsh`.